### PR TITLE
feat (SC-590): add access_level column to spreadsheets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,5 +9,6 @@ For instructions, see the [changelog confluence page](https://epcpower.atlassian
 
 ### Added
 
+- SC-590: Added access level column to the SunSpec and static modbus spreadsheet output.
 - SC-572: Added changelog for release notes.
 

--- a/src/epcpm/cli/sunspectostaticmodbus.py
+++ b/src/epcpm/cli/sunspectostaticmodbus.py
@@ -315,6 +315,7 @@ def cli(input_sunspec_filename: str, output_staticmodbus_filename: str) -> None:
             "scale_factor_uuid",
             "enumeration_uuid",
             "type_uuid",
+            "access_level",
             "not_implemented",
             "uuid",
             "class_name",

--- a/src/epcpm/importexport.py
+++ b/src/epcpm/importexport.py
@@ -161,6 +161,7 @@ def full_export(
             scale_factor_uuid=True,
             enumeration_uuid=True,
             type_uuid=True,
+            access_level=True,
             not_implemented=True,
             uuid=True,
             class_name=True,

--- a/src/epcpm/staticmodbustoxls.py
+++ b/src/epcpm/staticmodbustoxls.py
@@ -159,9 +159,8 @@ class FunctionData:
                 and parameter.uses_interface_item()
             )
             row.parameter_uses_interface_item = uses_interface_item
-            access_level_uuid = parameter.access_level_uuid
-            if access_level_uuid is not None:
-                access_level = self.parameter_uuid_finder(access_level_uuid)
+            if parameter.access_level_uuid is not None:
+                access_level = self.parameter_uuid_finder(parameter.access_level_uuid)
                 row.access_level = access_level.value
 
         if type_node.name == "pad":
@@ -245,9 +244,8 @@ class FunctionDataBitfieldMember:
                 and parameter.uses_interface_item()
             )
             row.parameter_uses_interface_item = uses_interface_item
-            access_level_uuid = parameter.access_level_uuid
-            if access_level_uuid is not None:
-                access_level = self.parameter_uuid_finder(access_level_uuid)
+            if parameter.access_level_uuid is not None:
+                access_level = self.parameter_uuid_finder(parameter.access_level_uuid)
                 row.access_level = access_level.value
 
         return row

--- a/src/epcpm/staticmodbustoxls.py
+++ b/src/epcpm/staticmodbustoxls.py
@@ -30,6 +30,7 @@ class Fields(epcpm.pm_helper.FieldsInterface):
     description = attr.ib(default=None, type=typing.Union[str, bool])
     field_type = attr.ib(default=None, type=typing.Union[str, bool])
     parameter_uses_interface_item = attr.ib(default=False, type=typing.Union[str, bool])
+    access_level = attr.ib(default=None, type=typing.Union[str, bool, int])
 
 
 field_names = Fields(
@@ -43,6 +44,7 @@ field_names = Fields(
     description="Description",
     field_type="Field Type",
     parameter_uses_interface_item="Implemented",
+    access_level="Access Level",
 )
 
 
@@ -157,6 +159,10 @@ class FunctionData:
                 and parameter.uses_interface_item()
             )
             row.parameter_uses_interface_item = uses_interface_item
+            access_level_uuid = parameter.access_level_uuid
+            if access_level_uuid is not None:
+                access_level = self.parameter_uuid_finder(access_level_uuid)
+                row.access_level = access_level.value
 
         if type_node.name == "pad":
             row.name = "Pad"
@@ -239,5 +245,9 @@ class FunctionDataBitfieldMember:
                 and parameter.uses_interface_item()
             )
             row.parameter_uses_interface_item = uses_interface_item
+            access_level_uuid = parameter.access_level_uuid
+            if access_level_uuid is not None:
+                access_level = self.parameter_uuid_finder(access_level_uuid)
+                row.access_level = access_level.value
 
         return row

--- a/src/epcpm/sunspectocsv.py
+++ b/src/epcpm/sunspectocsv.py
@@ -492,9 +492,8 @@ class DataPointBitfieldMember:
             row.parameter_uuid = parameter.uuid
             row.parameter_uses_interface_item = uses_interface_item
             row.type_uuid = self.wrapped.type_uuid
-            access_level_uuid = parameter.access_level_uuid
-            if access_level_uuid is not None:
-                access_level = self.parameter_uuid_finder(access_level_uuid)
+            if parameter.access_level_uuid is not None:
+                access_level = self.parameter_uuid_finder(parameter.access_level_uuid)
                 row.access_level = access_level.value
             row.not_implemented = False
             row.size = 0
@@ -576,9 +575,10 @@ class TableRepeatingBlockReference:
                 #     ).abbreviation
 
                 row.enumeration_uuid = table_element2.enumeration_uuid
-                access_level_uuid = parameter.access_level_uuid
-                if access_level_uuid is not None:
-                    access_level = self.parameter_uuid_finder(access_level_uuid)
+                if parameter.access_level_uuid is not None:
+                    access_level = self.parameter_uuid_finder(
+                        parameter.access_level_uuid
+                    )
                     row.access_level = access_level.value
                 row.not_implemented = point.not_implemented
                 row.uuid = point.uuid
@@ -710,9 +710,8 @@ class Point:
             row.scale_factor_uuid = row_scale_factor_uuid
             row.enumeration_uuid = parameter.enumeration_uuid
             row.type_uuid = self.wrapped.type_uuid
-            access_level_uuid = parameter.access_level_uuid
-            if access_level_uuid is not None:
-                access_level = self.parameter_uuid_finder(access_level_uuid)
+            if parameter.access_level_uuid is not None:
+                access_level = self.parameter_uuid_finder(parameter.access_level_uuid)
                 row.access_level = access_level.value
             row.not_implemented = self.wrapped.not_implemented
             row.uuid = self.wrapped.uuid

--- a/src/epcpm/sunspectocsv.py
+++ b/src/epcpm/sunspectocsv.py
@@ -49,6 +49,7 @@ class Fields(epcpm.pm_helper.FieldsInterface):
     scale_factor_uuid = attr.ib(default=None, type=typing.Union[str, bool])
     enumeration_uuid = attr.ib(default=None, type=typing.Union[str, bool])
     type_uuid = attr.ib(default=None, type=typing.Union[str, bool])
+    access_level = attr.ib(default=None, type=typing.Union[str, bool])
     not_implemented = attr.ib(default=None, type=typing.Union[str, bool])
     uuid = attr.ib(default=None, type=typing.Union[str, bool])
     class_name = attr.ib(default=None, type=typing.Union[str, bool])
@@ -491,6 +492,10 @@ class DataPointBitfieldMember:
             row.parameter_uuid = parameter.uuid
             row.parameter_uses_interface_item = uses_interface_item
             row.type_uuid = self.wrapped.type_uuid
+            access_level_uuid = parameter.access_level_uuid
+            if access_level_uuid is not None:
+                access_level = self.parameter_uuid_finder(access_level_uuid)
+                row.access_level = access_level.value
             row.not_implemented = False
             row.size = 0
             row.bit_offset = self.wrapped.bit_offset
@@ -571,6 +576,10 @@ class TableRepeatingBlockReference:
                 #     ).abbreviation
 
                 row.enumeration_uuid = table_element2.enumeration_uuid
+                access_level_uuid = parameter.access_level_uuid
+                if access_level_uuid is not None:
+                    access_level = self.parameter_uuid_finder(access_level_uuid)
+                    row.access_level = access_level.value
                 row.not_implemented = point.not_implemented
                 row.uuid = point.uuid
                 row.class_name = "TableRepeatingBlockReferenceDataPointReference"
@@ -701,6 +710,10 @@ class Point:
             row.scale_factor_uuid = row_scale_factor_uuid
             row.enumeration_uuid = parameter.enumeration_uuid
             row.type_uuid = self.wrapped.type_uuid
+            access_level_uuid = parameter.access_level_uuid
+            if access_level_uuid is not None:
+                access_level = self.parameter_uuid_finder(access_level_uuid)
+                row.access_level = access_level.value
             row.not_implemented = self.wrapped.not_implemented
             row.uuid = self.wrapped.uuid
             row.class_name = "DataPoint"


### PR DESCRIPTION
## Jira Story
[SC-590](https://epcpower.atlassian.net/browse/SC-590)

## About
Request to add the parameter access level to the SunSpec and static modbus spreadsheet (CSV) output. Add to the `MODBUS-EPC.xlsx` and `MODBUS_SunSpec-EPC.csv` spreadsheets.

## Associated Pull Requests

*   [x] [grid-tied](https://github.com/epcpower/grid-tied/pull/225)

## Update Changelog

*   [x] Changelog updated

## Reproduction Steps

## Validation
