### PR TITLE
Feature/sc 623

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ For instructions, see the [changelog confluence page](https://epcpower.atlassian
 
 ### Added
 
+- SC-623: Removed rejected callback field from c interface structures.
 - SC-590: Added access level column to the SunSpec and static modbus spreadsheet output.
 - SC-572: Added changelog for release notes.
 

--- a/src/epcpm/parameterstointerface.py
+++ b/src/epcpm/parameterstointerface.py
@@ -1590,7 +1590,6 @@ def create_item(
             common_initializers,
             "},",
             *variable_or_getter_setter,
-            f".rejectedCallback = {rejected_callback},",
             *meta_initializer,
         ],
         "};",


### PR DESCRIPTION
## Jira Story
SC-623

## About
Removed the rejected callback field from the generated C interface structure items. This is related to the change in rejected callback functions handling to free flash.

## Associated Pull Requests

*   https://github.com/epcpower/grid-tied/pull/247

## Update Changelog

*   [ ] Changelog updated

## Reproduction Steps

## Validation
