### PR TITLE
Fix/static modbus scale factor

### DIFF
--- a/src/epcpm/parameterstointerface.py
+++ b/src/epcpm/parameterstointerface.py
@@ -45,7 +45,7 @@ staticmodbus_types = {
     "string": "PackedString",
     "bitfield16": "sunsU16",
     "bitfield32": "sunsU32",
-    "staticmodbussf": "sunsS16"
+    "staticmodbussf": "sunsS16",
 }
 
 
@@ -227,7 +227,9 @@ class Root:
         if len(can_nodes_with_parameter_uuid) != len(parameter_uuid_to_can_node):
             uuids = [u.parameter_uuid for u in can_nodes_with_parameter_uuid]
             print("\n".join(set(str(u) for u in uuids if uuids.count(u) > 1)))
-            raise Exception(f"Lengths not equal: {len(can_nodes_with_parameter_uuid)} vs {len(parameter_uuid_to_can_node)}")
+            raise Exception(
+                f"Lengths not equal: {len(can_nodes_with_parameter_uuid)} vs {len(parameter_uuid_to_can_node)}"
+            )
 
         c = []
         h = []
@@ -621,7 +623,9 @@ class Parameter:
                     wrapped=factor_point,
                     parameter_uuid_finder=self.parameter_uuid_finder,
                 )
-                scale_factor_variable = staticmodbus_factor_builder.interface_variable_name()
+                scale_factor_variable = (
+                    staticmodbus_factor_builder.interface_variable_name()
+                )
 
         interface_item_type = (
             f"InterfaceItem_{var_or_func}_{types[parameter.internal_type].name}"
@@ -887,11 +891,8 @@ def can_getter_setter_variable(can_signal, parameter, var_or_func_or_table):
             f"{can_signal.tree_parent.name}"
             f".{can_signal.name}"
         )
-    elif can_signal.tree_parent.tree_parent.name == 'CAN':
-        can_variable = (
-            f"&{can_signal.tree_parent.name}"
-            f".{can_signal.name}"
-        )
+    elif can_signal.tree_parent.tree_parent.name == "CAN":
+        can_variable = f"&{can_signal.tree_parent.name}" f".{can_signal.name}"
     else:
         can_variable = (
             f"&{can_signal.tree_parent.tree_parent.name}"

--- a/src/epcpm/parameterstointerface.py
+++ b/src/epcpm/parameterstointerface.py
@@ -419,8 +419,8 @@ class FunctionData:
     parameter_uuid_finder = attr.ib()
 
     def interface_variable_name(self):
-        # TODO: Remove when staticmodbus.common.variable is eliminated in the future.
-        return "NULL"
+        parameter = self.parameter_uuid_finder(self.wrapped.parameter_uuid)
+        return f"&{parameter.internal_variable}"
 
 
 @builders(epcpm.staticmodbusmodel.FunctionDataBitfieldMember)
@@ -611,6 +611,17 @@ class Parameter:
             staticmodbus_setter = "_".join(
                 str(x) for x in getter_setter_list + ["setter"]
             )
+
+            if getattr(staticmodbus_point, "factor_uuid", False):
+                factor_point = self.staticmodbus_root.model.node_from_uuid(
+                    staticmodbus_point.factor_uuid,
+                )
+
+                staticmodbus_factor_builder = builders.wrap(
+                    wrapped=factor_point,
+                    parameter_uuid_finder=self.parameter_uuid_finder,
+                )
+                scale_factor_variable = staticmodbus_factor_builder.interface_variable_name()
 
         interface_item_type = (
             f"InterfaceItem_{var_or_func}_{types[parameter.internal_type].name}"


### PR DESCRIPTION
## Jira Story

## About

Fix static modbus scale factor for use in rm-dc.

## Associated Pull Requests

*   [ ] _
*   [ ] _

## Update Changelog

*   [ ] Changelog updated

## Reproduction Steps

## Validation

```
#pragma DATA_SECTION(interfaceItem_badac06b_0ea1_4908_8379_1f96d7840a1b, "Interface")
// Parameters > 4. Diagnostics > 1. Anomaly Supervisor > 1. Event Log > 06. Event 6 > Timestamp
// badac06b-0ea1-4908-8379-1f96d7840a1b
InterfaceItem_functions_float const interfaceItem_badac06b_0ea1_4908_8379_1f96d7840a1b = {
    .common = {
        .sunspecScaleFactor = &INTF_fixedScaleFactors[6U],
        .canScaleFactor = 1e-06f,
        .scaleFactorUpdater = NULL,
        .internalScaleFactor = 0,
        .rejectFromInactiveInterface = false,
        .sunspec = {
            .variable = NULL,
            .getter = NULL,
            .setter = NULL,
        },
        .staticmodbus = {
            .getter = InterfaceItem_functions_float_staticmodbus_sunsS32_getter,
            .setter = InterfaceItem_functions_float_staticmodbus_sunsS32_setter,
        },
        .can = {
            .variable = &ParameterQuery.AssEventLog_Event_6_1.aTimestamp,
            .getter = InterfaceItem_functions_float_can_int32_t_getter,
            .setter = InterfaceItem_functions_float_can_int32_t_setter,
        },
        .access_level = CAN_Enum_AccessLevel_Service_Tech,
        .uuid = {0xdaba, 0x6bc0, 0xa10e, 0x0849, 0x7983, 0x961f, 0x84d7, 0x1b0a},
    },
    .getter = ASS_getEventLogEvent_6_Timestamp,
    .setter = NULL,
    .meta_values = {
        [Meta_UserDefault - 1] = 0.0f,
        [Meta_FactoryDefault - 1] = 0.0f,
        [Meta_Min - 1] = (-INFINITY),
        [Meta_Max - 1] = (INFINITY)
    }
};

```